### PR TITLE
Add commands to show/hide/start/stop/split

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Windower and Ashita are both great, but they offer different APIs for inspecting
 
 - `/captain hide` to stop showing the GUI elements
 - `/captain show` to show the GUI elements
+- `/captain start` to begin a capture
+- `/captain stop` to end a capture
+- `/captain split` to roll over to a new capture
 - `SHIFT + DRAG` to drag text boxes around
 - (TODO) To start a capture press: `CTRL + ALT + C`
 - (TODO) To end a capture press: `CTRL + ALT + V`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Windower and Ashita are both great, but they offer different APIs for inspecting
 
 ### General
 
+- `/captain hide` to stop showing the GUI elements
+- `/captain show` to show the GUI elements
 - `SHIFT + DRAG` to drag text boxes around
 - (TODO) To start a capture press: `CTRL + ALT + C`
 - (TODO) To end a capture press: `CTRL + ALT + V`

--- a/backend/backend_ashita_v3.lua
+++ b/backend/backend_ashita_v3.lua
@@ -14,8 +14,17 @@ backend.register_event_unload = function(func)
     ashita.register_event('unload', func)
 end
 
-backend.register_command = function(str)
-    -- TODO
+backend.register_command = function(func)
+    local addonCommand = string.format('/%s', _addon.command)
+    ashita.register_event('command', function(cmd, nType)
+        local args = cmd:args()
+        if #args < 1 or args[1] ~= addonCommand then
+            return
+        end
+
+        local strippedArgs = { unpack(args, 2) }
+        func(strippedArgs)
+    end)
 end
 
 backend.register_event_incoming_packet = function(func)

--- a/backend/backend_ashita_v4.lua
+++ b/backend/backend_ashita_v4.lua
@@ -6,6 +6,7 @@
 local backend = {}
 
 require('common')
+local chat = require('chat')
 local imgui = require('imgui')
 
 local WHITE = { 1.0,  1.0,  1.0, 1.0 }
@@ -160,8 +161,7 @@ backend.script_path = function()
 end
 
 backend.add_to_chat = function(mode, msg)
-    -- TODO
-    print(msg)
+    print(chat.header(addon.name):append(chat.message(msg)))
 end
 
 backend.player_name = function()

--- a/backend/backend_ashita_v4.lua
+++ b/backend/backend_ashita_v4.lua
@@ -25,8 +25,17 @@ backend.register_event_unload = function(func)
     ashita.events.register('unload', 'unload_cb', func)
 end
 
-backend.register_command = function(str)
-    -- TODO
+backend.register_command = function(func)
+    local addonCommand = string.format('/%s', addon.command)
+    ashita.events.register('command', 'command_cb', function(e)
+        local args = e.command:args()
+        if #args < 1 or args[1] ~= addonCommand then
+            return
+        end
+
+        local strippedArgs = { unpack(args, 2) }
+        func(strippedArgs)
+    end)
 end
 
 backend.register_event_incoming_packet = function(func)
@@ -72,7 +81,7 @@ backend.register_event_prerender = function(func)
             imgui.SetNextWindowSize({ -1, -1, }, ImGuiCond_Always)
             imgui.SetNextWindowSizeConstraints({ -1, -1, }, { FLT_MAX, FLT_MAX, })
 
-            if box.text ~= nil and imgui.Begin(box.name, true, flags) then
+            if box.text ~= nil and box.visible and imgui.Begin(box.name, true, flags) then
                 if box.title then
                     imgui.TextColored(CORAL, box.title)
                     imgui.Separator()

--- a/backend/backend_windower_v4.lua
+++ b/backend/backend_windower_v4.lua
@@ -18,8 +18,11 @@ backend.register_event_unload = function(func)
     windower.register_event('unload', func)
 end
 
-backend.register_command = function(str)
-    -- TODO
+backend.register_command = function(func)
+    windower.register_event('addon command', function(...)
+        local args = {...}
+        func(args)
+    end)
 end
 
 backend.register_event_incoming_packet = function(func)

--- a/backend/files.lua
+++ b/backend/files.lua
@@ -106,7 +106,7 @@ function files.create_path(f)
         table.insert(splitFolders, token)
     end
 
-    newpath = backend.script_path()
+    local newpath = backend.script_path()
     for _, dir in pairs(splitFolders) do
         newpath = newpath .. dir .. '/'
 

--- a/captain.lua
+++ b/captain.lua
@@ -31,6 +31,20 @@ display.targetInfo = {}
 display.inputPacket = {}
 display.outputPacket = {}
 
+local function ShowGui()
+    display.playerInfo:show()
+    display.targetInfo:show()
+    display.inputPacket:show()
+    display.outputPacket:show()
+end
+
+local function HideGui()
+    display.playerInfo:hide()
+    display.targetInfo:hide()
+    display.inputPacket:hide()
+    display.outputPacket:hide()
+end
+
 -- Hooks
 backend.register_event_load(function()
     local date = os.date('*t')
@@ -50,7 +64,18 @@ end)
 backend.register_event_unload(function()
 end)
 
-backend.register_command(function(str)
+backend.register_command(function(args)
+    if #args == 0 then
+        return
+    end
+
+    if args[1] == 'help' then
+        -- TODO
+    elseif args[1] == 'show' then
+        ShowGui()
+    elseif args[1] == 'hide' then
+        HideGui()
+    end
 end)
 
 backend.register_event_incoming_packet(function(id, data, size)


### PR DESCRIPTION
hi zach! i've recently stepped into playing retail and wanted to be able to contribute captures as i go. these are some changes i made for my own coziness and figured i'd share (`captain` seems to be the only good option for ashita4!)

- added a command `hide` to disable the various data displays
- added a command `show` to enable the various data displays
- `captain` will not immediately begin capturing when loaded
- added a command `start` to begin a new capture
- added a command `stop` to stop capturing
- added a command `split` to continue capturing in a new directory
    - looking at it now, this is not meaningfully different to just running `/captain start`. maybe worth just ditching?

what i _haven't_ done is add the keybinds - i'm familiar with ashita 3 and 4, but not so much windower. if you're content with not all backends supporting them yet, i can go ahead and add that to the ashitas.

i've been using this for a couple of weeks in ashita4 - i can't speak to its quality in ashita3 (yet) or windower, though. let me know if you have questions or want anything changed.