### PR TITLE
[ashitav4] Add job/sjob name/level, zone to info string for player

### DIFF
--- a/backend/backend_ashita_v4.lua
+++ b/backend/backend_ashita_v4.lua
@@ -87,7 +87,7 @@ backend.register_event_prerender = function(func)
                     imgui.TextColored(CORAL, box.title)
                     imgui.Separator()
                 end
-                imgui.Text(box.text)
+                imgui.TextUnformatted(box.text)
                 imgui.End()
             end
         end
@@ -205,15 +205,23 @@ backend.get_player_entity_data = function()
     local player = AshitaCore:GetMemoryManager():GetPlayer()
     local index = party:GetMemberTargetIndex(0)
 
+    local playerZoneID = party:GetMemberZone(0)
+
     local playerEntityData =
     {
         name = party:GetMemberName(0),
         serverId = party:GetMemberServerId(0),
+        mJob = AshitaCore:GetResourceManager():GetString("jobs.names_abbr", player:GetMainJob()),
+        sJob = AshitaCore:GetResourceManager():GetString("jobs.names_abbr", player:GetSubJob()),
+        mJobLevel = player:GetMainJobLevel(),
+        sJobLevel = player:GetSubJobLevel(),
+        zoneID = playerZoneID,
+        zoneName = AshitaCore:GetResourceManager():GetString('zones.names', playerZoneID),
         targIndex = index,
         x = string.format('%+08.03f', entity:GetLocalPositionX(index)),
         y = string.format('%+08.03f', entity:GetLocalPositionY(index)),
         z = string.format('%+08.03f', entity:GetLocalPositionZ(index)),
-        r = utils.headingToByteRotation(entity:GetLocalPositionYaw(index)),
+        r = string.format('%03d', utils.headingToByteRotation(entity:GetLocalPositionYaw(index))),
     }
     return playerEntityData
 end

--- a/captain.lua
+++ b/captain.lua
@@ -144,16 +144,31 @@ backend.register_event_prerender(function()
         return
     end
 
+    local playerJobString = '(99NIN/49WAR) '
+
+    --  TODO: implement for Windower/Ashitav3
+    if playerData.mJob then
+        playerJobString = string.format("(%02d%s/%02d%s) ", playerData.mJobLevel, playerData.mJob, playerData.sJobLevel, playerData.sJob)
+    end
+
+    local zoneInfo = 'Zone: 000 (Zone Name)'
+
+    --  TODO: implement for Windower/Ashitav3
+    if playerData.zoneID then
+        zoneInfo = string.format("Zone: %03d, (%s)", playerData.zoneID, playerData.zoneName)
+    end
+
     local playerOutputStr = 'Player: ' ..
     playerData.name .. ' ' ..
-    '(99NIN/49WAR) ' .. -- TODO
+    playerJobString ..
     'ID: ' .. playerData.serverId .. ' ' ..
     'IDX: ' .. playerData.targIndex .. ' ' ..
     'X: ' .. playerData.x .. ' ' ..
     'Y: ' .. playerData.y .. ' ' ..
     'Z: ' .. playerData.z .. ' ' ..
     'R: ' .. playerData.r .. ' ' ..
-    'Zone: 000 (Zone Name)'
+    zoneInfo
+
     display.playerInfo:updateText(playerOutputStr)
 
     local targetData = backend.get_target_entity_data()


### PR DESCRIPTION
Adding some missing info to captain's display header:

![image](https://github.com/zach2good/captain/assets/60417494/06e40a78-b08b-450f-abaf-29c116da6c2d)
